### PR TITLE
fix: Use `fsPath` instead of `path` to get correct path for diff

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ async function createCommitMessage(repo: Repository) {
 
 			const ind = await repo.diffIndexWithHEAD()
 			const callbacks = ind.map((change) =>
-				getSummaryUriDiff(repo, change.uri.path),
+				getSummaryUriDiff(repo, change.uri.fsPath),
 			)
 			const summaries = await Promise.all(callbacks)
 			const commitMessage = await getCommitMessage(summaries)


### PR DESCRIPTION
Hello. I found this extension while looking for ways to use ollama.
Unfortunately, it didn't work in my Windows VS Code, so I checked the problem and found that the uri delivered to `git diff` was like this: `/d:/foo/bar.txt`.
One simple change solved the problem at least on my PC.
It would be great if you could review it and publish.
Thank you for the useful extension.

fix #1 