### PR TITLE
fix(ci): align engines.vscode for v3.1.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"url": "https://github.com/anjerodev/commitollama.git"
 	},
 	"engines": {
-		"vscode": "^1.120.0"
+		"vscode": "^1.125.0"
 	},
 	"categories": [
 		"Machine Learning",
@@ -217,17 +217,6 @@
 		"sinon": "22.1.0",
 		"typescript": "7.0.2",
 		"zod": "4.4.3"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"@vscode/vsce-sign",
-			"esbuild",
-			"keytar"
-		],
-		"overrides": {
-			"serialize-javascript": "7.0.7",
-			"diff": "9.0.0"
-		}
 	},
 	"extensionDependencies": [
 		"vscode.git"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  serialize-javascript: 7.0.7
+  diff: 9.0.0
+
 importers:
 
   .:
@@ -922,10 +926,6 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  diff@7.0.0:
-    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
-    engines: {node: '>=0.3.1'}
-
   diff@9.0.0:
     resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
@@ -1566,9 +1566,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   rc-config-loader@4.1.4:
     resolution: {integrity: sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==}
 
@@ -1648,9 +1645,6 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   serialize-javascript@7.0.7:
     resolution: {integrity: sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==}
@@ -2790,8 +2784,6 @@ snapshots:
   detect-libc@2.1.2:
     optional: true
 
-  diff@7.0.0: {}
-
   diff@9.0.0: {}
 
   dom-serializer@2.0.0:
@@ -3303,7 +3295,7 @@ snapshots:
       browser-stdout: 1.3.1
       chokidar: 4.0.3
       debug: 4.4.3(supports-color@8.1.1)
-      diff: 7.0.0
+      diff: 9.0.0
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
       glob: 10.5.0
@@ -3314,7 +3306,7 @@ snapshots:
       minimatch: 9.0.9
       ms: 2.1.3
       picocolors: 1.1.1
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.7
       strip-json-comments: 3.1.1
       supports-color: 8.1.1
       workerpool: 9.3.4
@@ -3484,10 +3476,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   rc-config-loader@4.1.4(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -3578,10 +3566,6 @@ snapshots:
   semver@5.7.2: {}
 
   semver@7.8.5: {}
-
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
 
   serialize-javascript@7.0.7: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,6 @@ allowBuilds:
   keytar: true
 minimumReleaseAgeExclude:
   - '@tanstack/ai@0.43.1'
+overrides:
+  serialize-javascript: 7.0.7
+  diff: 9.0.0


### PR DESCRIPTION
## Summary
- Fix packaging failure: `@types/vscode 1.125.0` was greater than `engines.vscode ^1.120.0`
- Bump `engines.vscode` to `^1.125.0`
- Move ignored `pnpm` package.json settings into `pnpm-workspace.yaml` (pnpm 11)

This follows failed release attempts on #127 (merged before the fix). Merge with the **Release** label to publish **v3.1.0**.

## Test plan
- [ ] CI passes
- [ ] Merge with **Release** label
- [ ] Confirm GitHub release `v3.1.0` and Marketplace publish succeed